### PR TITLE
Replace deprecated studly_case laravel helper usage

### DIFF
--- a/src/Commands/BreadGenerator.php
+++ b/src/Commands/BreadGenerator.php
@@ -101,7 +101,7 @@ class BreadGenerator extends GeneratorCommand
      */
     protected function getNameInput()
     {
-        return trim(studly_case($this->argument('name')));
+        return trim(Str::studly($this->argument('name')));
     }
 
     /**
@@ -126,7 +126,7 @@ class BreadGenerator extends GeneratorCommand
      */
     protected function createModel()
     {
-        $table = studly_case($this->argument('name'));
+        $table = Str::studly($this->argument('name'));
         $this->call('make:model', [
             'name' => $table
         ]);


### PR DESCRIPTION
From Laravel 5.9 some of the helper functions have been deprecated.
https://github.com/laravel/framework/pull/27504/files

In this PR `Str::studly` has been used instead of `studly_case`.

It should also fix the issue https://github.com/jeffochoa/voyager-bread-generator/issues/3