### PR TITLE
Replaced studly_case method with Str::studly

### DIFF
--- a/src/Commands/BreadGenerator.php
+++ b/src/Commands/BreadGenerator.php
@@ -101,7 +101,7 @@ class BreadGenerator extends GeneratorCommand
      */
     protected function getNameInput()
     {
-        return trim(studly_case($this->argument('name')));
+        return trim(Str::studly($this->argument('name')));
     }
 
     /**
@@ -126,7 +126,7 @@ class BreadGenerator extends GeneratorCommand
      */
     protected function createModel()
     {
-        $table = studly_case($this->argument('name'));
+        $table = Str::studly($this->argument('name'));
         $this->call('make:model', [
             'name' => $table
         ]);


### PR DESCRIPTION
Replaced studly_case method with Str::studly because Laravel latest versions not supporting studly_case method.